### PR TITLE
fix:button text not bind

### DIFF
--- a/__tests/test_button.py
+++ b/__tests/test_button.py
@@ -1,0 +1,33 @@
+import pytest
+from ex4nicegui.reactive import rxui
+from nicegui import ui
+from ex4nicegui import to_ref
+from .screen import ScreenPage
+
+
+class Uilts:
+    def __init__(self, page: ScreenPage, testid="target"):
+        self.page = page
+        self.testid = testid
+
+    def assert_button_text(self, text: str):
+        assert self.page.get_by_test_id(self.testid).inner_text() == text
+
+
+def test_ref_text(page: ScreenPage, page_path: str):
+    r_text = to_ref("old text")
+
+    @ui.page(page_path)
+    def _():
+        rxui.button(r_text).props('data-testid="target"').props("no-caps")
+
+    page.open(page_path)
+
+    utils = Uilts(page)
+
+    page.wait()
+    utils.assert_button_text(text="old text")
+
+    r_text.value = "new text"
+    page.wait()
+    utils.assert_button_text(text="new text")

--- a/ex4nicegui/reactive/officials/button.py
+++ b/ex4nicegui/reactive/officials/button.py
@@ -57,7 +57,7 @@ class ButtonBindableUi(SingleValueBindableUi[str, ui.button]):
         @effect
         def _():
             ele = self.element
-            ele._props["text"] = ref_ui.value
+            ele._props["label"] = ref_ui.value
             ele.update()
 
         return self


### PR DESCRIPTION
bug:
```python
from ex4nicegui.reactive import rxui

text = to_ref("old text")
rxui.button(text).props("no-caps")
text.value='new text'
```

button text still 'old text'