### PR TITLE
bi ui_select duplicate selected values appearing in the dropdown box

### DIFF
--- a/__tests/test_bi_ui_select.py
+++ b/__tests/test_bi_ui_select.py
@@ -168,3 +168,36 @@ def test_default_value(page: ScreenPage, page_path: str):
         ["a", "c1", "0"],
         ["b", "c1", "200"],
     ]
+
+
+def test_update_options(page: ScreenPage, page_path: str):
+    @ui.page(page_path)
+    def _():
+        df = pd.DataFrame(
+            {
+                "cls1": [
+                    "x1",
+                    "x1",
+                    "x1",
+                    "x2",
+                    "x2",
+                    "x2",
+                ],
+                "cls2": ["a", "b", "c", "c", "b", "a"],
+            }
+        )
+        ds = bi.data_source(df)
+
+        set_test_id(ds.ui_select("cls1", value="x1", multiple=False), "cls1")
+        set_test_id(ds.ui_select("cls2", clearable=False), "cls2")
+
+    page.open(page_path)
+
+    cls1_select = SelectUtils(page, "cls1")
+    cls2_select = SelectUtils(page, "cls2")
+
+    cls2_select.click_and_select("a")
+    cls1_select.click_and_select("x2")
+    cls2_select.click_and_select("a")
+
+    assert cls2_select.get_selected_values() == []

--- a/__tests/utils.py
+++ b/__tests/utils.py
@@ -54,7 +54,7 @@ class SelectUtils:
         self.target_locator = self.page.get_by_test_id(test_id)
 
     def click(self):
-        self.target_locator.click()
+        self.target_locator.click(position={"x": 5, "y": 5})
 
     def get_options_values(self):
         return self.page.locator(
@@ -66,6 +66,7 @@ class SelectUtils:
 
     def click_and_select(self, value: str):
         self.click()
+        self.page.wait_for_timeout(500)
         self.page.get_by_role("option", name=value).click()
 
     def get_input_value(self):

--- a/ex4nicegui/bi/elements/ui_select.py
+++ b/ex4nicegui/bi/elements/ui_select.py
@@ -110,9 +110,9 @@ def ui_select(
             if value not in options:
                 value = ""
 
-        cp.set_options(options, value=value)
-        # cp.value = value
-        # cp.update()
+        cp.set_options(options, value=[])
+        cp.value = value
+        cp.update()
 
     result = SelectResult(cp, self._dataSource, ref_value)
     self._dataSource._register_component(

--- a/ex4nicegui/bi/elements/ui_select.py
+++ b/ex4nicegui/bi/elements/ui_select.py
@@ -111,6 +111,8 @@ def ui_select(
                 value = ""
 
         cp.set_options(options, value=value)
+        # cp.value = value
+        # cp.update()
 
     result = SelectResult(cp, self._dataSource, ref_value)
     self._dataSource._register_component(


### PR DESCRIPTION
This PR fixes the issue of incorrect and duplicate selected values appearing in the dropdown box(#68). 

This problem may be a bug in nicegui's select component. For now, we are using alternative solutions.
