### PR TITLE
Support bind style

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -215,6 +215,32 @@ Each element in the list is a responsive variable that returns the class name
 
 ---
 
+### bind-style
+
+```python
+from nicegui import ui
+from ex4nicegui.reactive import rxui
+from ex4nicegui.utils.signals import to_ref
+
+
+bg_color = to_ref("blue")
+text_color = to_ref("red")
+
+rxui.label("test").bind_style(
+    {
+        "background-color": bg_color,
+        "color": text_color,
+    }
+)
+
+rxui.select(["blue", "green", "yellow"], label="bg color", value=bg_color)
+rxui.select(["red", "green", "yellow"], label="text color", value=text_color)
+```
+
+`bind_style` passed into dictionary, `key` is style name, `value` is style value, responsive string
+
+---
+
 ## responsive
 
 ```python

--- a/README.md
+++ b/README.md
@@ -217,6 +217,32 @@ rxui.label("binding to arrays").bind_classes([bg_color_class, text_color_class])
 
 列表中每个元素为返回类名的响应式变量
 
+---
+
+### bind-style
+
+```python
+from nicegui import ui
+from ex4nicegui.reactive import rxui
+from ex4nicegui.utils.signals import to_ref
+
+
+bg_color = to_ref("blue")
+text_color = to_ref("red")
+
+rxui.label("test").bind_style(
+    {
+        "background-color": bg_color,
+        "color": text_color,
+    }
+)
+
+rxui.select(["blue", "green", "yellow"], label="bg color", value=bg_color)
+rxui.select(["red", "green", "yellow"], label="text color", value=text_color)
+```
+
+`bind_style` 传入字典，`key` 为样式名字，`value` 为样式值，响应式字符串或数值
+
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ rxui.select(["blue", "green", "yellow"], label="bg color", value=bg_color)
 rxui.select(["red", "green", "yellow"], label="text color", value=text_color)
 ```
 
-`bind_style` 传入字典，`key` 为样式名字，`value` 为样式值，响应式字符串或数值
+`bind_style` 传入字典，`key` 为样式名字，`value` 为样式值，响应式字符串
 
 
 ---

--- a/__tests/test_bindableUi.py
+++ b/__tests/test_bindableUi.py
@@ -148,3 +148,62 @@ def test_bind_classes(page: ScreenPage, page_path: str):
         label.expect_to_have_class("bg-green text-yellow")
 
     test3()
+
+
+def test_bind_style(page: ScreenPage, page_path: str):
+    @ui.page(page_path)
+    def _():
+        # binding to dict
+        def binding_to_dict():
+            bg_color = to_ref("blue")
+            text_color = to_ref("red")
+
+            test_prefix = "binding_to_dict"
+
+            set_test_id(
+                rxui.select(
+                    ["blue", "green", "yellow"], label="bg color", value=bg_color
+                ),
+                f"{test_prefix}_select1",
+            )
+
+            set_test_id(
+                rxui.select(
+                    ["red", "green", "yellow"], label="text color", value=text_color
+                ),
+                f"{test_prefix}_select2",
+            )
+            set_test_id(
+                rxui.label("test").bind_style(
+                    {
+                        "background-color": bg_color,
+                        "color": text_color,
+                    }
+                ),
+                f"{test_prefix}_label",
+            )
+
+        binding_to_dict()
+
+    page.open(page_path)
+    page.wait()
+
+    def test_binding_to_dict():
+        test_prefix = "binding_to_dict"
+        select1 = SelectUtils(page, f"{test_prefix}_select1")
+        select2 = SelectUtils(page, f"{test_prefix}_select2")
+        label = LabelUtils(page, f"{test_prefix}_label")
+
+        assert label.get_style_attr_value() == "background-color: blue; color: red;"
+
+        #
+        select1.click_and_select("green")
+
+        assert label.get_style_attr_value() == "background-color: green; color: red;"
+
+        #
+        select2.click_and_select("yellow")
+
+        assert label.get_style_attr_value() == "background-color: green; color: yellow;"
+
+    test_binding_to_dict()

--- a/__tests/utils.py
+++ b/__tests/utils.py
@@ -72,6 +72,9 @@ class BaseUiUtils:
     def expect_not_to_have_class(self, classes: Union[List[str], str]):
         expect(self.target_locator).not_to_have_class(classes)
 
+    def get_style_attr_value(self) -> str:
+        return self.target_locator.evaluate("element => element.getAttribute('style')")
+
 
 class SelectUtils(BaseUiUtils):
     def __init__(self, screen_page: ScreenPage, test_id: str) -> None:

--- a/ex4nicegui/reactive/officials/base.py
+++ b/ex4nicegui/reactive/officials/base.py
@@ -203,6 +203,14 @@ class BindableUi(Generic[TWidget]):
         return self
 
     def bind_style(self, style: Dict[str, Union[ReadonlyRef[str], Ref[str]]]):
+        """data binding is manipulating an element's style
+
+        @see - https://github.com/CrystalWindSnake/ex4nicegui/blob/main/README.en.md#bind-style
+        @中文文档 - https://gitee.com/carson_add/ex4nicegui/tree/main/#bind-style
+
+        Args:
+            classes (_T_bind_classes_type):
+        """
         if isinstance(style, dict):
             for name, ref_obj in style.items():
                 if is_ref(ref_obj):

--- a/ex4nicegui/reactive/officials/base.py
+++ b/ex4nicegui/reactive/officials/base.py
@@ -202,6 +202,18 @@ class BindableUi(Generic[TWidget]):
 
         return self
 
+    def bind_style(self, style: Dict[str, Union[ReadonlyRef[str], Ref[str]]]):
+        if isinstance(style, dict):
+            for name, ref_obj in style.items():
+                if is_ref(ref_obj):
+
+                    @effect
+                    def _(name=name, ref_obj=ref_obj):
+                        self.element._style[name] = ref_obj.value
+                        self.element.update()
+
+        return self
+
 
 class SingleValueBindableUi(BindableUi[TWidget], Generic[T, TWidget]):
     def __init__(self, value: TMaybeRef[T], element: TWidget) -> None:

--- a/ex4nicegui/reactive/officials/base.py
+++ b/ex4nicegui/reactive/officials/base.py
@@ -209,7 +209,7 @@ class BindableUi(Generic[TWidget]):
         @中文文档 - https://gitee.com/carson_add/ex4nicegui/tree/main/#bind-style
 
         Args:
-            classes (_T_bind_classes_type):
+            style (Dict[str, Union[ReadonlyRef[str], Ref[str]]]): _description_
         """
         if isinstance(style, dict):
             for name, ref_obj in style.items():


### PR DESCRIPTION
```python
from nicegui import ui
from ex4nicegui.reactive import rxui
from ex4nicegui.utils.signals import to_ref


bg_color = to_ref("blue")
text_color = to_ref("red")

rxui.label("test").bind_style(
    {
        "background-color": bg_color,
        "color": text_color,
    }
)

rxui.select(["blue", "green", "yellow"], label="bg color", value=bg_color)
rxui.select(["red", "green", "yellow"], label="text color", value=text_color)


ui.run()
```