### PR TITLE
Support Execute all responsive triggers  after each ui event loop

### DIFF
--- a/__tests/test_number.py
+++ b/__tests/test_number.py
@@ -62,8 +62,7 @@ def test_on_change(page: ScreenPage, page_path: str):
 
     target = InputNumberUtils(page, "target")
 
-    target.input_text("1111")
-    page.wait(1500)
+    target.fill_text("1111")
     assert value_on_change == 1111.0
 
 

--- a/__tests/test_signe.py
+++ b/__tests/test_signe.py
@@ -121,3 +121,5 @@ def test_post_event_scheduler(page: ScreenPage, page_path: str):
 
     page.wait(1500)
     assert dummy == ["start", "end", "effect"]
+
+    reset_execution_scheduler("sync")

--- a/ex4nicegui/__init__.py
+++ b/ex4nicegui/__init__.py
@@ -10,6 +10,7 @@ from ex4nicegui.utils.signals import (
     ref,
     on,
     event_batch,
+    reset_execution_scheduler,
     _TMaybeRef as TMaybeRef,
 )
 from ex4nicegui import tools

--- a/ex4nicegui/utils/scheduler.py
+++ b/ex4nicegui/utils/scheduler.py
@@ -27,6 +27,13 @@ _T_Scheduler = Literal["sync", "post-event"]
 
 
 def reset_execution_scheduler(type: _T_Scheduler):
+    """Reset responsive scheduler type
+
+    Args:
+        type (Literal["sync", "post-event"]):
+            `sync`: triggers the relevant computation as soon as the ref is assigned.
+            `post-event`: performs other trigger calculations after the event loop in which the ref is assigned.
+    """
     if type == "post-event":
         signe_utils.get_current_executor().set_default_execution_scheduler(
             PostEventExecutionScheduler()

--- a/ex4nicegui/utils/scheduler.py
+++ b/ex4nicegui/utils/scheduler.py
@@ -1,0 +1,19 @@
+from signe import utils as signe_utils
+import asyncio
+
+
+class EventDelayExecutionScheduler(signe_utils.ExecutionScheduler):
+    def __init__(self) -> None:
+        super().__init__()
+        self.__has_callback = False
+
+    def run(self):
+        if not self.__has_callback:
+            asyncio.get_running_loop().call_soon(self.real_run)
+            self.__has_callback = True
+
+    def real_run(
+        self,
+    ):
+        super().run()
+        self.__has_callback = False

--- a/ex4nicegui/utils/scheduler.py
+++ b/ex4nicegui/utils/scheduler.py
@@ -23,7 +23,7 @@ class PostEventExecutionScheduler(signe_utils.BatchExecutionScheduler):
         self.__has_callback = False
 
 
-_T_Scheduler = Literal["default", "post-event"]
+_T_Scheduler = Literal["sync", "post-event"]
 
 
 def reset_execution_scheduler(type: _T_Scheduler):
@@ -31,7 +31,7 @@ def reset_execution_scheduler(type: _T_Scheduler):
         signe_utils.get_current_executor().set_default_execution_scheduler(
             PostEventExecutionScheduler()
         )
-    else:
+    elif type == "sync":
         signe_utils.get_current_executor().set_default_execution_scheduler(
             signe_utils.ExecutionScheduler()
         )

--- a/ex4nicegui/utils/scheduler.py
+++ b/ex4nicegui/utils/scheduler.py
@@ -1,8 +1,9 @@
 from signe import utils as signe_utils
 import asyncio
+from typing import Literal
 
 
-class EventDelayExecutionScheduler(signe_utils.BatchExecutionScheduler):
+class PostEventExecutionScheduler(signe_utils.BatchExecutionScheduler):
     def __init__(self) -> None:
         super().__init__()
         self.__has_callback = False
@@ -20,3 +21,17 @@ class EventDelayExecutionScheduler(signe_utils.BatchExecutionScheduler):
     ):
         super().run_batch()
         self.__has_callback = False
+
+
+_T_Scheduler = Literal["default", "post-event"]
+
+
+def reset_execution_scheduler(type: _T_Scheduler):
+    if type == "post-event":
+        signe_utils.get_current_executor().set_default_execution_scheduler(
+            PostEventExecutionScheduler()
+        )
+    else:
+        signe_utils.get_current_executor().set_default_execution_scheduler(
+            signe_utils.ExecutionScheduler()
+        )

--- a/ex4nicegui/utils/scheduler.py
+++ b/ex4nicegui/utils/scheduler.py
@@ -2,18 +2,21 @@ from signe import utils as signe_utils
 import asyncio
 
 
-class EventDelayExecutionScheduler(signe_utils.ExecutionScheduler):
+class EventDelayExecutionScheduler(signe_utils.BatchExecutionScheduler):
     def __init__(self) -> None:
         super().__init__()
         self.__has_callback = False
 
     def run(self):
         if not self.__has_callback:
-            asyncio.get_running_loop().call_soon(self.real_run)
+            try:
+                asyncio.get_running_loop().call_soon(self.real_run)
+            except RuntimeError:
+                super().run_batch()
             self.__has_callback = True
 
     def real_run(
         self,
     ):
-        super().run()
+        super().run_batch()
         self.__has_callback = False

--- a/ex4nicegui/utils/signals.py
+++ b/ex4nicegui/utils/signals.py
@@ -245,7 +245,8 @@ def ref_computed(
     if fn:
         if _is_class_define_method(fn):
             return cast(
-                ref_computed_method[T], ref_computed_method(fn, computed_args=kws)
+                ref_computed_method[T],
+                ref_computed_method(fn, computed_args=kws),  # type: ignore
             )  # type: ignore
 
         getter = computed(fn, **kws, scope=_CLIENT_SCOPE_MANAGER.get_scope())

--- a/ex4nicegui/utils/signals.py
+++ b/ex4nicegui/utils/signals.py
@@ -118,17 +118,29 @@ def to_ref(maybe_ref: _TMaybeRef[T]):
     return cast(Ref[T], ref(maybe_ref))
 
 
-def ref(value: T):
-    comp = (
-        False
-        if not isinstance(
-            value,
-            (str, int, float, date, datetime),
-        )
-        and (value is not None)
-        else None
+def _is_comp_values(value):
+    return isinstance(
+        value,
+        (str, int, float, date, datetime),
     )
-    # getter, setter = createSignal(value, comp)
+
+
+def _ref_comp_with_None(old, new):
+    # Prevent Constant Repeated Assignment of None
+    if old is None and new is None:
+        return True
+
+    return False
+
+
+def ref(value: T):
+    comp = False  # Default never equal
+
+    if _is_comp_values(value):
+        comp = None  # comparison of `==`
+
+    if value is None:
+        comp = _ref_comp_with_None
 
     s = Signal(signe_utils.get_current_executor(), value, SignalOption(comp))
 

--- a/ex4nicegui/utils/signals.py
+++ b/ex4nicegui/utils/signals.py
@@ -20,9 +20,16 @@ from typing import (
     Union,
     Sequence,
 )
+from .scheduler import EventDelayExecutionScheduler
 from nicegui import ui
 
 T = TypeVar("T")
+
+
+signe_utils.get_current_executor().set_default_execution_scheduler(
+    EventDelayExecutionScheduler()
+)
+
 
 _CLIENT_SCOPE_MANAGER = NgClientScopeManager()
 
@@ -130,7 +137,7 @@ def ref(value: T):
     )
     # getter, setter = createSignal(value, comp)
 
-    s = Signal(signe_utils.exec, value, SignalOption(comp))
+    s = Signal(signe_utils.get_current_executor(), value, SignalOption(comp))
 
     return cast(Ref[T], Ref(s.getValue, s.setValue, s))
 


### PR DESCRIPTION
```python
from nicegui import ui
from ex4nicegui import to_ref, effect

a = to_ref("old")

@effect
def _():
    print("effect:", a.value)

def onclick():
    print("start")
    a.value = "new"
    print("end")

ui.button("click", on_click=onclick)
```

Normally, the print message is:
```
start
effect: new
end
```

If a delayed scheduler is applied, all effcets will occur after the event is over:
```
start
end
effect: new
```



