### PR TITLE
Introduces reactive scopes within standalone client connections

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -403,6 +403,31 @@ ui.button("change b", on_click=change_b)
 
 ---
 
+### `new_scope`
+
+By default, all watch functions are automatically destroyed when the client connection is disconnected. For finer-grained control, the `new_scope` function can be utilized.
+
+```python
+from nicegui import ui
+from ex4nicegui import rxui, to_ref, effect, new_scope
+
+a = to_ref(0.0)
+
+scope1 = new_scope()
+
+@scope1.run
+def _():
+    @effect
+    def _():
+        print(f"scope 1:{a.value}")
+
+
+rxui.number(value=a)
+rxui.button("dispose scope 1", on_click=scope1.dispose)
+```
+
+---
+
 ## functionality
 
 ### vmodel

--- a/README.md
+++ b/README.md
@@ -414,6 +414,31 @@ ui.button("change b", on_click=change_b)
 
 ---
 
+### `new_scope`
+
+默认情况下，所有检测函数在客户端连接断开时自动销毁。如果需要更细粒度的控制，可以使用 `new_scope`
+
+```python
+from nicegui import ui
+from ex4nicegui import rxui, to_ref, effect, new_scope
+
+a = to_ref(0.0)
+
+scope1 = new_scope()
+
+@scope1.run
+def _():
+    @effect
+    def _():
+        print(f"scope 1:{a.value}")
+
+
+rxui.number(value=a)
+rxui.button("dispose scope 1", on_click=scope1.dispose)
+```
+
+---
+
 
 ## 组件功能
 

--- a/__tests/test_scope.py
+++ b/__tests/test_scope.py
@@ -1,0 +1,70 @@
+from ex4nicegui.reactive import rxui
+from nicegui import ui
+from ex4nicegui import to_ref, effect, new_scope, on
+from .screen import ScreenPage
+from .utils import set_test_id, ButtonUtils, InputUtils, LabelUtils
+
+
+def test_can_dispose_temporarily(page: ScreenPage, page_path: str):
+    @ui.page(page_path)
+    def _():
+        a = to_ref("0")
+        scope1_text = to_ref("")
+        scope2_text = to_ref("")
+
+        scope1 = new_scope()
+
+        @scope1.run
+        def _():
+            @on(a)
+            def _():
+                scope1_text.value = f"scope 1:{a.value}"
+
+        scope2 = new_scope()
+
+        @scope2.run
+        def _():
+            @effect
+            def _():
+                scope2_text.value = f"scope 2:{a.value}"
+
+        set_test_id(rxui.input(value=a), "input")
+        set_test_id(rxui.label(scope1_text), "scope1_text")
+        set_test_id(rxui.label(scope2_text), "scope2_text")
+        set_test_id(
+            rxui.button("dispose scope 1", on_click=scope1.dispose), "dispose_scope1"
+        )
+        set_test_id(
+            rxui.button("dispose scope 2", on_click=scope2.dispose), "dispose_scope2"
+        )
+
+    page.open(page_path)
+    page.wait(600)
+
+    input = InputUtils(page, "input")
+    scope1_text = LabelUtils(page, "scope1_text")
+    scope2_text = LabelUtils(page, "scope2_text")
+    dispose_scope1 = ButtonUtils(page, "dispose_scope1")
+    dispose_scope2 = ButtonUtils(page, "dispose_scope2")
+
+    # page.pause()
+
+    scope1_text.expect_contain_text("scope 1:0")
+    scope2_text.expect_contain_text("scope 2:0")
+
+    input.fill_text("1")
+    # page.pause()
+    scope1_text.expect_contain_text("scope 1:1")
+    scope2_text.expect_contain_text("scope 2:1")
+
+    dispose_scope1.click()
+
+    input.fill_text("2")
+    scope1_text.expect_contain_text("scope 1:1")
+    scope2_text.expect_contain_text("scope 2:2")
+
+    dispose_scope2.click()
+
+    input.fill_text("3")
+    scope1_text.expect_contain_text("scope 1:1")
+    scope2_text.expect_contain_text("scope 2:2")

--- a/ex4nicegui/__init__.py
+++ b/ex4nicegui/__init__.py
@@ -20,7 +20,7 @@ from ex4nicegui.utils.signals import (
     is_reactive,
 )
 from ex4nicegui.utils.asyncComputed import async_computed
-
+from ex4nicegui.utils.clientScope import new_scope
 
 __all__ = [
     "async_computed",
@@ -43,6 +43,7 @@ __all__ = [
     "batch",
     "to_raw",
     "is_setter_ref",
+    "new_scope",
 ]
 
 __version__ = "0.6.5"

--- a/ex4nicegui/utils/clientScope.py
+++ b/ex4nicegui/utils/clientScope.py
@@ -17,6 +17,15 @@ class NgClientScopeManager:
         self._client_scope_map: Dict[_TClientID, NgScopeSuite] = {}
 
     def new_scope(self, detached: bool = False):
+        """Create a scope that can collect all reactive watch functions within it, allowing for a unified destruction process.
+
+        @see - https://github.com/CrystalWindSnake/ex4nicegui/blob/main/README.en.md#new_scope
+        @中文文档 - https://gitee.com/carson_add/ex4nicegui/tree/main/#new_scope
+
+        Args:
+            detached (bool, optional): Whether the scope should be detached from the client. Defaults to False.
+
+        """
         return self.get_current_scope().scope(detached=detached)
 
     def get_current_scope(self):

--- a/ex4nicegui/utils/clientScope.py
+++ b/ex4nicegui/utils/clientScope.py
@@ -42,3 +42,7 @@ class NgClientScopeManager:
 
 
 _CLIENT_SCOPE_MANAGER = NgClientScopeManager()
+
+
+def new_scope():
+    pass

--- a/ex4nicegui/utils/clientScope.py
+++ b/ex4nicegui/utils/clientScope.py
@@ -2,7 +2,6 @@ from typing import Dict
 from signe.core.scope import ScopeSuite
 from nicegui import Client, ui
 
-
 _TClientID = str
 
 
@@ -18,12 +17,9 @@ class NgClientScopeManager:
         self._client_scope_map: Dict[_TClientID, NgScopeSuite] = {}
 
     def new_scope(self, detached: bool = False):
-        return self.get_current_scope().scope(detached)
+        return self.get_current_scope().scope(detached=detached)
 
     def get_current_scope(self):
-        # if len(ng_context.get_slot_stack()) <= 0:
-        #     return
-
         client = ui.context.client
 
         if client.id not in self._client_scope_map:
@@ -35,7 +31,7 @@ class NgClientScopeManager:
                 @client.on_disconnect
                 def _(e: Client):
                     if e.id in self._client_scope_map:
-                        self._client_scope_map[e.id]._top_scope.dispose()
+                        self._client_scope_map[e.id]._top_scope.dispose()  # type: ignore
                         del self._client_scope_map[e.id]
 
         return self._client_scope_map[client.id]
@@ -44,5 +40,4 @@ class NgClientScopeManager:
 _CLIENT_SCOPE_MANAGER = NgClientScopeManager()
 
 
-def new_scope():
-    pass
+new_scope = _CLIENT_SCOPE_MANAGER.new_scope


### PR DESCRIPTION
This PR introduces a mechanism to more granularly collect reactive scopes within standalone client connections.

Here is the preliminary API design concept:
```python
from nicegui import ui
from ex4nicegui import rxui, to_ref, effect, new_scope

a = to_ref(0.0)

scope1 = new_scope()

@scope1.run
def _():
    @effect
    def _():
        print(f"scope 1:{a.value}")


scope2 = new_scope()

@scope2.run
def _():
    @effect
    def _():
        print(f"scope 2:{a.value}")


rxui.number(value=a)

rxui.button("dispose scope 1", on_click=scope1.dispose)
rxui.button("dispose scope 2", on_click=scope2.dispose)
```

