### PR TITLE
Fix `rxui.echarts.from_pyecharts` cannot use a function.

### DIFF
--- a/__tests/test_echarts.py
+++ b/__tests/test_echarts.py
@@ -223,6 +223,23 @@ def test_pyecharts(browser: BrowserManager, page_path: str):
     assert "formatter" in chart_opts["yAxis"][0]["axisLabel"]
 
 
+def test_pyecharts_from_fn(browser: BrowserManager, page_path: str):
+    @ui.page(page_path)
+    def _():
+        data = to_ref([0.1, 0.2])
+
+        def bar_chart():
+            return Bar().add_xaxis(["A", "B"]).add_yaxis("ratio", data.value)
+
+        rxui.echarts.from_pyecharts(bar_chart).classes("target")
+
+    page = browser.open(page_path)
+
+    target = page.ECharts(".target")
+
+    target.assert_canvas_exists()
+
+
 def test_click_event(browser: BrowserManager, page_path: str):
     @ui.page(page_path)
     def _():

--- a/ex4nicegui/reactive/officials/echarts.py
+++ b/ex4nicegui/reactive/officials/echarts.py
@@ -94,13 +94,14 @@ class EChartsBindableUi(BindableUi[echarts]):
 
     @classmethod
     def from_pyecharts(cls, chart: TMaybeRef):
-        if is_ref(chart):
+        if is_ref(chart) or callable(chart):
 
             @ref_computed
             def chart_opt():
-                if not bool(chart.value):
+                chart_value = to_value(chart)
+                if not bool(chart_value):
                     return {}
-                return PyechartsUtils._chart2opts(chart.value)
+                return PyechartsUtils._chart2opts(chart_value)
 
             return cls(chart_opt)
 


### PR DESCRIPTION

```python
data = to_ref([0.1, 0.2])

def bar_chart():
    return Bar().add_xaxis(["A", "B"]).add_yaxis("ratio", data.value)

rxui.echarts.from_pyecharts(bar_chart)
```