### PR TITLE
All binding methods can support plain values to enable the implicit mode of the view model.

### DIFF
--- a/__tests/test_bindableUi.py
+++ b/__tests/test_bindableUi.py
@@ -239,6 +239,46 @@ def test_bind_prop(browser: BrowserManager, page_path: str):
     expect(target2).to_have_attribute("prop", "hello foo world")
 
 
+def test_bind_props(browser: BrowserManager, page_path: str):
+    @ui.page(page_path)
+    def _():
+        label = to_ref("hello")
+        bool_prop = to_ref(False)
+
+        def get_props_str():
+            return f'prop="{label.value}"'
+
+        rxui.element("div").props('innerText="target1"').bind_props(get_props_str)
+        rxui.element("div").props('innerText="target2"').bind_props(
+            {
+                "prop": label,
+                "bool-prop": bool_prop,
+            }
+        )
+
+        rxui.input(value=label).classes("input")
+        rxui.checkbox(value=bool_prop).classes("checkbox")
+
+    page = browser.open(page_path)
+    pw_page = page._page
+
+    target1 = pw_page.get_by_text("target1")
+    target2 = pw_page.get_by_text("target2")
+    input = page.Input(".input")
+    checkbox = page.Checkbox(".checkbox")
+
+    expect(target1).to_have_attribute("prop", "hello")
+    expect(target2).to_have_attribute("prop", "hello")
+    expect(target2).not_to_have_attribute("bool-prop", "")
+
+    input.fill_text("hello foo")
+    checkbox.click()
+
+    expect(target1).to_have_attribute("prop", "hello foo")
+    expect(target2).to_have_attribute("prop", "hello foo")
+    expect(target2).to_have_attribute("bool-prop", "true")
+
+
 def test_handle_delete(browser: BrowserManager, page_path: str):
     @fn
     def caller():

--- a/ex4nicegui/reactive/base.py
+++ b/ex4nicegui/reactive/base.py
@@ -162,7 +162,7 @@ class BindableUi(Generic[TWidget]):
         """data binding is manipulating an element's props
 
         Args:
-            props (TMaybeRef[str]):  a reference to the props to bind to
+            props (Union[Dict[str, TMaybeRef[Any]], TMaybeRef[str]]): dict of prop name and ref value
 
         ## usage
 
@@ -174,6 +174,10 @@ class BindableUi(Generic[TWidget]):
                 return f'{"flat" if flat.value else ""} {"size=" + size.value}'
 
             rxui.button("click me").bind_props(props_str)
+            rxui.button("click me").bind_props({
+                "outlined": outlined,
+                "size": size,
+            })
 
         """
         if isinstance(props, dict):

--- a/ex4nicegui/reactive/base.py
+++ b/ex4nicegui/reactive/base.py
@@ -181,7 +181,7 @@ class BindableUi(Generic[TWidget]):
 
         return self
 
-    def bind_visible(self, value: TGetterOrReadonlyRef[bool]):
+    def bind_visible(self, value: TMaybeRef[bool]):
         @self._ui_effect
         def _():
             element = cast(ui.element, self.element)
@@ -189,7 +189,7 @@ class BindableUi(Generic[TWidget]):
 
         return self
 
-    def bind_not_visible(self, value: TGetterOrReadonlyRef[bool]):
+    def bind_not_visible(self, value: TMaybeRef[bool]):
         return self.bind_visible(lambda: not to_value(value))
 
     def on(

--- a/ex4nicegui/reactive/base.py
+++ b/ex4nicegui/reactive/base.py
@@ -180,7 +180,7 @@ class BindableUi(Generic[TWidget]):
 
             def props_str():
                 props_dict = (
-                    f'{name if isinstance(raw_value,bool) else f"{name}={raw_value}"}'
+                    f"""{name if isinstance(raw_value,bool) else f"{name}='{raw_value}'"}"""
                     for name, value in props.items()
                     if (raw_value := to_value(value))
                 )

--- a/ex4nicegui/reactive/base.py
+++ b/ex4nicegui/reactive/base.py
@@ -152,6 +152,29 @@ class BindableUi(Generic[TWidget]):
         """
         return self.element.remove(element)
 
+    def bind_props(self, props: TMaybeRef[str]):
+        """data binding is manipulating an element's props
+
+        Args:
+            props (TMaybeRef[str]):  a reference to the props to bind to
+
+        ## usage
+
+        .. code-block:: python
+            outlined = to_ref(True)
+            size = to_ref("xs")
+
+            def props_str():
+                return f"outlined={outlined.value} size={size.value}"
+
+            rxui.button("click me").bind_props(props_str)
+
+        """
+
+        @self._ui_signal_on(props, onchanges=False, deep=False)
+        def _(state: WatchedState):
+            self.props(add=state.current, remove=state.previous)
+
     def bind_prop(self, prop: str, value: TGetterOrReadonlyRef[Any]):
         """data binding is manipulating an element's property
 

--- a/ex4nicegui/reactive/mixins/backgroundColor.py
+++ b/ex4nicegui/reactive/mixins/backgroundColor.py
@@ -5,10 +5,7 @@ from typing import (
 )
 
 import signe
-from ex4nicegui.utils.signals import (
-    TGetterOrReadonlyRef,
-    WatchedState,
-)
+from ex4nicegui.utils.signals import WatchedState, TMaybeRef
 from nicegui import ui
 from ex4nicegui.reactive.systems import color_system
 
@@ -17,10 +14,9 @@ class BackgroundColorableMixin(Protocol):
     _ui_signal_on: Callable[[Callable[..., Any]], signe.Effect[None]]
 
     @property
-    def element(self) -> ui.element:
-        ...
+    def element(self) -> ui.element: ...
 
-    def _bind_background_color(self, value: TGetterOrReadonlyRef[str]):
+    def _bind_background_color(self, value: TMaybeRef[str]):
         @self._ui_signal_on(value, onchanges=False)  # type: ignore
         def _(state: WatchedState):
             if state.previous is not None:
@@ -30,7 +26,7 @@ class BackgroundColorableMixin(Protocol):
 
             self.element.update()
 
-    def bind_color(self, color: TGetterOrReadonlyRef[str]):
+    def bind_color(self, color: TMaybeRef[str]):
         """bind color to the element
 
         Args:

--- a/ex4nicegui/reactive/mixins/disableable.py
+++ b/ex4nicegui/reactive/mixins/disableable.py
@@ -8,10 +8,7 @@ from typing import (
 )
 
 import signe
-from ex4nicegui.utils.signals import (
-    TGetterOrReadonlyRef,
-    to_value,
-)
+from ex4nicegui.utils.signals import to_value, TMaybeRef
 from nicegui.elements.mixins.disableable_element import DisableableElement
 
 
@@ -22,10 +19,9 @@ class DisableableMixin(Protocol):
     _ui_effect: Callable[[Callable[..., Any]], signe.Effect[None]]
 
     @property
-    def element(self) -> DisableableElement:
-        ...
+    def element(self) -> DisableableElement: ...
 
-    def bind_enabled(self, value: TGetterOrReadonlyRef[bool]):
+    def bind_enabled(self, value: TMaybeRef[bool]):
         @self._ui_effect
         def _():
             raw_value = to_value(value)
@@ -34,7 +30,7 @@ class DisableableMixin(Protocol):
 
         return self
 
-    def bind_disable(self, value: TGetterOrReadonlyRef[bool]):
+    def bind_disable(self, value: TMaybeRef[bool]):
         @self._ui_effect
         def _():
             raw_value = not to_value(value)

--- a/ex4nicegui/reactive/mixins/textColor.py
+++ b/ex4nicegui/reactive/mixins/textColor.py
@@ -9,6 +9,7 @@ import signe
 from ex4nicegui.utils.signals import (
     TGetterOrReadonlyRef,
     WatchedState,
+    TMaybeRef,
 )
 from nicegui import ui
 from ex4nicegui.reactive.systems import color_system
@@ -18,10 +19,9 @@ class TextColorableMixin(Protocol):
     _ui_signal_on: Callable[[Callable[[TGetterOrReadonlyRef[str]], Any]], signe.Effect]
 
     @property
-    def element(self) -> ui.element:
-        ...
+    def element(self) -> ui.element: ...
 
-    def _bind_text_color(self, color: TGetterOrReadonlyRef[str]):
+    def _bind_text_color(self, color: TMaybeRef[str]):
         @self._ui_signal_on(color, onchanges=False)  # type: ignore
         def _(state: WatchedState):
             if state.previous is not None:
@@ -31,7 +31,7 @@ class TextColorableMixin(Protocol):
 
             self.element.update()
 
-    def bind_color(self, color: TGetterOrReadonlyRef[str]):
+    def bind_color(self, color: TMaybeRef[str]):
         """bind text color to the element
 
         Args:
@@ -46,16 +46,14 @@ class HtmlTextColorableMixin(Protocol):
     _ui_signal_on: Callable[[Callable[[TGetterOrReadonlyRef[str]], Any]], signe.Effect]
 
     @property
-    def element(self) -> ui.element:
-        ...
+    def element(self) -> ui.element: ...
 
-    def bind_style(self, style: Dict[str, TGetterOrReadonlyRef[Any]]):
-        ...
+    def bind_style(self, style: Dict[str, TMaybeRef[Any]]): ...
 
-    def _bind_text_color(self, value: TGetterOrReadonlyRef[str]):
+    def _bind_text_color(self, value: TMaybeRef[str]):
         return self.bind_style({"color": value})
 
-    def bind_color(self, color: TGetterOrReadonlyRef[str]):
+    def bind_color(self, color: TMaybeRef[str]):
         """bind text color to the element
 
         Args:

--- a/ex4nicegui/reactive/officials/checkbox.py
+++ b/ex4nicegui/reactive/officials/checkbox.py
@@ -36,6 +36,8 @@ class CheckboxBindableUi(
 
         value_kws = pc.get_values_kws()
 
+        print("=" * 10)
+        print(value_kws)
         element = ui.checkbox(**value_kws)
         super().__init__(element)  # type: ignore
 

--- a/ex4nicegui/reactive/officials/checkbox.py
+++ b/ex4nicegui/reactive/officials/checkbox.py
@@ -35,9 +35,6 @@ class CheckboxBindableUi(
         )
 
         value_kws = pc.get_values_kws()
-
-        print("=" * 10)
-        print(value_kws)
         element = ui.checkbox(**value_kws)
         super().__init__(element)  # type: ignore
 

--- a/ex4nicegui/reactive/view_model.py
+++ b/ex4nicegui/reactive/view_model.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import Callable, List, Union, Type, TypeVar
+from typing import Any, Callable, List, Union, Type, TypeVar
 from ex4nicegui.utils.signals import (
     deep_ref,
     is_ref,
@@ -14,7 +14,9 @@ from ex4nicegui.utils.types import ReadonlyRef
 from functools import partial
 from signe.core.reactive import NoProxy
 from ex4nicegui.utils.proxy.descriptor import class_var_setter
-
+from ex4nicegui.utils.proxy.bool import BoolProxy
+from ex4nicegui.utils.proxy.int import IntProxy
+from ex4nicegui.utils.proxy.float import FloatProxy
 
 _CACHED_VARS_FLAG = "__vm_cached__"
 _LIST_VAR_FLAG = "__vm_list_var__"
@@ -94,6 +96,18 @@ class ViewModel(NoProxy):
             )
 
         return result
+
+    @staticmethod
+    def is_bool(value: Any):
+        return isinstance(value, bool) or isinstance(value, BoolProxy)
+
+    @staticmethod
+    def is_int(value: Any):
+        return isinstance(value, int) or isinstance(value, IntProxy)
+
+    @staticmethod
+    def is_float(value: Any):
+        return isinstance(value, float) or isinstance(value, FloatProxy)
 
 
 def _recursive_to_value(value_or_model):

--- a/ex4nicegui/utils/proxy/__init__.py
+++ b/ex4nicegui/utils/proxy/__init__.py
@@ -2,10 +2,14 @@ from .string import StringProxy
 from .int import IntProxy
 from .list import ListProxy
 from .float import FloatProxy
+from .bool import BoolProxy
+from .date import DateProxy
 
 
 def is_base_type_proxy(obj):
-    return isinstance(obj, (StringProxy, IntProxy, ListProxy, FloatProxy))
+    return isinstance(
+        obj, (StringProxy, IntProxy, ListProxy, FloatProxy, BoolProxy, DateProxy)
+    )
 
 
 def to_ref_if_base_type_proxy(obj):
@@ -13,6 +17,7 @@ def to_ref_if_base_type_proxy(obj):
         return obj._ref
     else:
         return obj
+
 
 def to_value_if_base_type_proxy(obj):
     if is_base_type_proxy(obj):

--- a/ex4nicegui/utils/proxy/descriptor.py
+++ b/ex4nicegui/utils/proxy/descriptor.py
@@ -92,6 +92,8 @@ class DateDescriptor(ProxyDescriptor[datetime.date]):
 def class_var_setter(cls: Type, name: str, value, list_var_flat: str) -> None:
     if value is None or isinstance(value, str):
         setattr(cls, name, StringDescriptor(name, value))
+    elif isinstance(value, bool):
+        setattr(cls, name, BoolDescriptor(name, value))
     elif isinstance(value, int):
         setattr(cls, name, IntDescriptor(name, value))
     elif callable(value) and hasattr(value, list_var_flat):
@@ -112,8 +114,6 @@ def class_var_setter(cls: Type, name: str, value, list_var_flat: str) -> None:
         # setattr(cls, name, DictDescriptor(name, value))
     elif isinstance(value, float):
         setattr(cls, name, FloatDescriptor(name, value))
-    elif isinstance(value, bool):
-        setattr(cls, name, BoolDescriptor(name, value))
     elif isinstance(value, datetime.date):
         setattr(cls, name, DateDescriptor(name, value))
     else:


### PR DESCRIPTION
- [x] `bind_classes` value supports non-ref
- [x] `bind_style` value supports non-ref
- [x] `bind_prop` value supports non-ref
- [x] `bind_style` accepts a function that gets the complete style dictionary
- [x] `bind_visible` accepts a plain value or a function
- [x] Added `bind_props`, supporting `mayberef[str]` or a dictionary
- [x] `bind_prop` value supports non-ref, using `on` instead of `effect`