### PR TITLE
Support for changing ECharts versions

### DIFF
--- a/ex4nicegui/__init__.py
+++ b/ex4nicegui/__init__.py
@@ -25,6 +25,7 @@ from ex4nicegui.utils.signals import (
 )
 from ex4nicegui.utils.asyncComputed import async_computed
 from ex4nicegui.utils.clientScope import new_scope
+from ex4nicegui.reactive.EChartsComponent.ECharts import reset_echarts_dependencies
 from .version import __version__
 
 __all__ = [
@@ -51,5 +52,6 @@ __all__ = [
     "is_setter_ref",
     "new_scope",
     "next_tick",
+    "reset_echarts_dependencies",
     "__version__",
 ]

--- a/ex4nicegui/reactive/EChartsComponent/ECharts.py
+++ b/ex4nicegui/reactive/EChartsComponent/ECharts.py
@@ -136,3 +136,24 @@ class echarts(Element, component="ECharts.js", dependencies=libraries):  # type:
             *args,
             timeout=timeout,
         )
+
+
+def reset_echarts_dependencies(echarts_js_file: Union[str, Path]):
+    """
+    Reset the echarts dependencies to use a custom echarts.min.js file.
+
+    :param echarts_js_file: path to the custom echarts.min.js file
+
+    Usage:
+    .. code-block:: python
+
+        from ex4nicegui import reset_echarts_dependencies
+        reset_echarts_dependencies("path/to/echarts.min.js")
+    """
+
+    global echarts
+
+    class _Echarts(echarts, component="ECharts.js", dependencies=[echarts_js_file]):
+        pass
+
+    echarts = _Echarts


### PR DESCRIPTION
```python
from pathlib import Path
from ex4nicegui import rxui, reset_echarts_dependencies

reset_echarts_dependencies(Path(__file__).parent / "echarts-v6.min.js")
```